### PR TITLE
koa-session支持在自定义ID方法里传入ctx

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -200,7 +200,7 @@ class ContextSession {
 
   create(val, externalKey) {
     debug('create session with val: %j externalKey: %s', val, externalKey);
-    if (this.store) this.externalKey = externalKey || this.opts.genid();
+    if (this.store) this.externalKey = externalKey || this.opts.genid(this.ctx);
     this.session = new Session(this, val);
   }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -200,7 +200,7 @@ class ContextSession {
 
   create(val, externalKey) {
     debug('create session with val: %j externalKey: %s', val, externalKey);
-    if (this.store) this.externalKey = externalKey || this.opts.genid(this.ctx);
+    if (this.store) this.externalKey = externalKey || this.opts.genid && this.opts.genid(this.ctx);
     this.session = new Session(this, val);
   }
 


### PR DESCRIPTION
原版koa-session已经支持在自定义ID方法里传入ctx。

限制多端登录、多平台登录，这个genid都是很常规的方案。